### PR TITLE
Enregistrement des signaux et création automatique des états par défa…

### DIFF
--- a/commande/apps.py
+++ b/commande/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class CommandeConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'commande'
+
+    def ready(self):
+        # Enregistrer les signaux (inclut l'initialisation des états par défaut)
+        from . import signals  # noqa: F401


### PR DESCRIPTION
…ut de EnumEtatCmd

Ajout de la méthode ready() dans CommandeConfig pour enregistrer les signaux au démarrage de l’application.

Introduction d’un handler post_migrate pour créer automatiquement les états par défaut de EnumEtatCmd après les migrations.

Garantit que les états requis des commandes sont toujours présents dans la base de données.